### PR TITLE
Fix `PRIORITY=` value sent to journald

### DIFF
--- a/lib/logger_journald_backend.ex
+++ b/lib/logger_journald_backend.ex
@@ -32,7 +32,7 @@ defmodule Logger.Backend.Journald do
       {md_key |> to_string |> String.upcase, :io_lib.format("~p", [md_val])}
     end
 
-    metalist = [{'MESSAGE', text}, {'PRIORITY', level_to_num(state.level)}] ++ metadata
+    metalist = [{'MESSAGE', text}, {'PRIORITY', level_to_num(level)}] ++ metadata
     :journald_api.sendv(metalist)
   end
 


### PR DESCRIPTION
`PRIORITY` was previously being set to the configured minimum log level, not the level that the log message was logged at.

Replace `state.level` with `level` to correct that.

Closes: #1